### PR TITLE
Change design of user show page

### DIFF
--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -8,7 +8,8 @@
         width: 40px;
         display: block;
         & > img {
-          width: 100%;
+          width: 170px;
+          margin-left: -130px;
         }
       }
     }

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class='container'>
     <header class="header">
       <p class='header_logo'>
-        <%= link_to image_tag("techpit-march-icon.png"), users_path %>
+        <%= link_to image_tag("job-matching.png"), users_path %>
       </p>
     </header>
     <div class='userInfo'>


### PR DESCRIPTION
# What
ユーザー詳細ページのロゴマークをアプリケーション名のロゴマークに変更。

# Why
ユーザー詳細ページにも、アプリケーション名のロゴマークを表示させ、全体の統一感を出すため。