### PR TITLE
Remove confirm password when was editing

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
@@ -54,7 +54,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def after_sign_up_path_for(resource)
   #   super(resource)
   # end
-  protected
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+  
   # The path used after sign up for inactive accounts.
   def after_update_path_for(resource)
     user_path(resource)

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -42,10 +42,6 @@
         <%= f.file_field :img_name %>
       </div>
 
-      <div class="form-group">
-        <%= f.label '更新するにはパスワードを入力してください' %>
-        <%= f.password_field :current_password, class: "form-control", autocomplete: "off" %>
-      </div>
       <div class="text-center">
         <%= f.submit '更新', class: "btn submitBtn" %>
       </div>


### PR DESCRIPTION
# What
ユーザー登録情報の編集時に必要だった「パスワード入力」をなくす実装。

# Why
より簡単に編集することができるようにするため。