### PR TITLE
Add secrets.yml in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 public/uploads/
+config/secrets.yml


### PR DESCRIPTION
# What
.gitignoreにsecrets.ymlを追加

# Why
secrets.ymlの情報をgit管理から外すため。