### PR TITLE
Add config action_cable in development.rb

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
+  config.action_cable.allowed_request_origins = [ '18.180.146.214', /http:\/\/example.*/ ]
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker


### PR DESCRIPTION
# What
action_cableの記述をdevelopment.rbにも記述。

# Why 
本番環境で非同期のチャット機能を動かすため。